### PR TITLE
fix scrollY assertion

### DIFF
--- a/cypress/integration/app_spec.js
+++ b/cypress/integration/app_spec.js
@@ -81,7 +81,7 @@ describe('PieChopper', function(){
 
       // https://on.cypress.io/invoke
       // https://on.cypress.io/then
-      cy.get('#model-selection-section').should(beScrolledToTop )
+      cy.get('#model-selection-section').should(beScrolledToTop)
     })
   })
 

--- a/cypress/integration/app_spec.js
+++ b/cypress/integration/app_spec.js
@@ -76,12 +76,17 @@ describe('PieChopper', function(){
       //
       // to figure out that the window is being scrolled we can simply
       // check the '#model-selection-section' top offset and once that equals
-      // the windows scrollY we know its been scrolled to the top
+      // the windows scrollY we know its been scrolled to the top (within 1 px)
       cy.contains('button', 'Begin').click()
 
       // https://on.cypress.io/invoke
       // https://on.cypress.io/then
-      cy.get('#model-selection-section').should(beScrolledToTop)
+      cy.get('#model-selection-section').invoke('offset').then(function(offset){
+          // using a cy.then here to create a closure of the offset
+
+          // https://on.cypress.io/window
+          cy.window().its('scrollY').should('closeTo', offset.top, 1)
+        })
     })
   })
 
@@ -365,9 +370,3 @@ describe('PieChopper', function(){
     })
   })
 })
-
-const beScrolledToTop = ($el) => {
-  const offset = $el.offset()
-  const win = $el[0].ownerDocument.defaultView
-  expect(win.scrollY).closeTo(offset.top, 1)
-}

--- a/cypress/integration/app_spec.js
+++ b/cypress/integration/app_spec.js
@@ -1,5 +1,3 @@
-
-
 describe('PieChopper', function(){
   beforeEach(function(){
     // Visiting before each test ensures the app

--- a/cypress/integration/app_spec.js
+++ b/cypress/integration/app_spec.js
@@ -1,3 +1,5 @@
+
+
 describe('PieChopper', function(){
   beforeEach(function(){
     // Visiting before each test ensures the app
@@ -81,12 +83,7 @@ describe('PieChopper', function(){
 
       // https://on.cypress.io/invoke
       // https://on.cypress.io/then
-      cy.get('#model-selection-section').invoke('offset').then(function(offset){
-          // using a cy.then here to create a closure of the offset
-
-          // https://on.cypress.io/window
-          cy.window().its('scrollY').should('eq', offset.top)
-        })
+      cy.get('#model-selection-section').should(beScrolledToTop )
     })
   })
 
@@ -370,3 +367,9 @@ describe('PieChopper', function(){
     })
   })
 })
+
+const beScrolledToTop = ($el) => {
+  const offset = $el.offset()
+  const win = $el[0].ownerDocument.defaultView
+  expect(win.scrollY).closeTo(offset.top, 1)
+}


### PR DESCRIPTION
fixes scrollY assertion that tests whether element has been scrolled to the top of the page.

Sometimes the test will fail with: 
```
CypressError: Timed out retrying: expected 511 to equal 511.99998474121094
```
seen in firefox here: https://circleci.com/gh/cypress-io/cypress/212283